### PR TITLE
Update to node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,18 +7,16 @@
     "updateall": "git pull; npm install; cd ..; if [ ! -d 'morteam-server-website' ]; then git clone https://github.com/mortorqrobotics/morteam-server-website; fi; cd morteam-server-website; git pull; npm install; cd ..; if [ ! -d 'morteam-web' ]; then git clone https://github.com/mortorqrobotics/morteam-web; fi; cd morteam-web; git pull; npm install; npm run build"
   },
   "dependencies": {
-    "bcrypt": "^0.8.5",
-    "bluebird": "^3.3.5",
-    "body-parser": "^1.14.0",
+    "bcrypt": "^1.0.2",
+    "bluebird": "^3.5.0",
+    "body-parser": "^1.17.1",
     "compression": "^1.6.2",
-    "connect-mongo": "^0.8.2",
-    "ejs": "^2.3.4",
-    "express": "^4.13.3",
-    "express-session": "^1.11.3",
+    "connect-mongo": "^1.3.2",
+    "express": "^4.15.2",
+    "express-session": "^1.15.1",
     "express-vhost": "^0.2.0",
-    "mongoose": "^4.4.6",
-    "multer": "^1.0.6",
-    "socket.io": "^1.3.5"
+    "mongoose": "^4.8.6",
+    "socket.io": "^1.7.3"
   },
   "repository": {
     "type": "git",

--- a/src/server.js
+++ b/src/server.js
@@ -10,7 +10,6 @@ let mongoose = require("mongoose"); // MongoDB ODM
 let session = require("express-session");
 let MongoStore = require("connect-mongo")(session);
 let ObjectId = mongoose.Types.ObjectId; // this is used to cast strings to MongoDB ObjectIds
-let multer = require("multer"); // for file uploads
 let vh = require("express-vhost");
 let compression = require("compression");
 


### PR DESCRIPTION
As explained [here](https://github.com/nodejs/LTS#lts-schedule), node 4 is nearing the end of its LTS and node 6 still has over a year left on its LTS, so this switches from 4 to 6. If you are using [nvm](https://github.com/creationix/nvm), run `nvm install 6 && npm alias default 6 && npm install -g npm` to update node and npm. To update modules in each affected repository, run `npm update`. That should work, but stuff tends to not work, so use `rm -rf node_modules && npm install` in case stuff does not work.